### PR TITLE
Make script easier to run

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ Your adb unlock key command will be generated under output
 Alternatively, download and run the script from an environment that supports python3 and crypt with the following command:
 
 ```sh
-$ python3 qadbkey-unlock2.py
+$ python3 /path/to/qadbkey-unlock2.py
 ```
 
 Example:
-
+* In this example the script exits in the users home directory 
 ```sh
 user@linuxcomputer:~$ python3 qadbkey-unlock2.py
 Enter the AT+QADBKEY? response: 12345678

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Modified by [iamromulan](https://github.com/iamromulan) to remove the sudo reqir
 https://onecompiler.com/python/3znepjcsq
 
 * Then replace the 12345678 with your responce from AT+QADBKEY? and click run
+
 Your adb unlock key command will be generated under output
 
 

--- a/README.md
+++ b/README.md
@@ -2,26 +2,32 @@
 
 This is a modification of Ryan Bradley's script to support RM5XX Series modems. It works for the RM520N-GL, RM502Q-AE, RM500Q-AE, EM120K-GL, and others.
 For more information, see [Getting ADB Access](https://github.com/natecarlson/quectel-rgmii-configuration-notes#getting-adb-access).
+This will allow you to replace the Quectel Forums step of the guide with an easier and faster method.
+
+Modified by [carp4](https://github.com/carp4) to allow AT+QADBKEY? to be entered directly and result displayed for RM5XX series modems.
+
+Modified by [iamromulan](https://github.com/iamromulan) to remove the sudo reqirement and query the user to input the AT+QADBKEY? response from the modem.
 
 ### How To Use
+* To use this script, simply go to the following URL:
+https://onecompiler.com/python/3znepjcsq
 
-To use this script, you must have the following:
-
-* `Python >= 3`
-* `The result of AT+QADBKEY? for your module.`
+* Then replace the 12345678 with your responce from AT+QADBKEY? and click run
+Your adb unlock key command will be generated under output
 
 
-Once you have obtained the prerequisites, run the script with the following command:
+Alternatively, download and run the script from an environment that supports python3 and crypt with the following command:
 
 ```sh
-$ sudo python3 qadbkey-unlock2.py -k <key>
+$ python3 qadbkey-unlock2.py
 ```
 
 Example:
 
 ```sh
-user@linux-mint:~/qadbkey-unlock$ sudo python3 qadbkey-unlock2.py -k 37677100
-AT+QADBKEY="hD0vaLg4a26u.SM"
+user@linuxcomputer:~$ python3 qadbkey-unlock2.py
+Enter the AT+QADBKEY? response: 12345678
+AT+QADBKEY="0jXKXQwSwMxYoeg"
 
 ```
 

--- a/qadbkey-unlock2.py
+++ b/qadbkey-unlock2.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 """
 File: qadbkey-unlock2.py
-Modified by carp4 to allow AT+QADBKEY? to be entered directly and result displayed for RM5XX series modems
+Modified by carp4 to allow AT+QADBKEY? to be entered directly and result displayed for RM5XX series modems.
+Modified by iamromulan to remove the sudo reqirement and query the user to input the AT+QADBKEY? response from the modem.
 Authors: hornetfighter515, FatherlyFox
 Year: 2021
 Version: 2.0
@@ -9,7 +10,10 @@ Credits: Original by igem, https://xnux.eu/devices/feature/qadbkey-unlock.c, htt
 Description: Works to assist in unlocking ADB access for the PinePhone.
 P.S. Thankyou for making a functional script hornetfighter515 ❤
 """
-import logging, os, argparse
+import logging
+import os
+import argparse
+import sys
 
 def generateUnlockKey(sn):
     """
@@ -20,14 +24,8 @@ def generateUnlockKey(sn):
     return c[12:27]
 
 def main():
-    if os.geteuid() != 0:
-        logging.error('This script must be run as a superuser, preferrably using \'sudo\'')
-        exit(1)
-    else:
-        parser = argparse.ArgumentParser()
-        parser.add_argument('-k', '--key', '--adb_key', required=True, help='Specify the adbkey, e.g. AT+QADBKEY?', type=str)     
-        args = parser.parse_args()
-        c = generateUnlockKey(args.key)
+        key = input("Enter the AT+QADBKEY? response: ")
+        c = generateUnlockKey(key)
         print('AT+QADBKEY="{0}"'.format(c))
 
 if __name__ == "__main__":


### PR DESCRIPTION
Removed the sudo requirement; changed to query the user to input the AT+QADBKEY? response from the modem.

Updated README.md to add an online executable version of this script. Updated examples and acknowledgements to reflect the changes to the script.